### PR TITLE
Tighten Dependabot update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,36 +8,42 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     groups:
       production-version-updates:
         applies-to: version-updates
         dependency-type: production
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       production-security-updates:
         applies-to: security-updates
         dependency-type: production
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       development-version-updates:
         applies-to: version-updates
         dependency-type: development
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       development-security-updates:
         applies-to: security-updates
         dependency-type: development
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1

--- a/build.gradle
+++ b/build.gradle
@@ -159,9 +159,9 @@ spotless {
 	java {
 		importOrder()
 		removeUnusedImports()
-		cleanthat().version('2.20').sourceCompatibility('21').addMutator('SafeAndConsensual').addMutator(
+		cleanthat().version('2.25').sourceCompatibility('21').addMutator('SafeAndConsensual').addMutator(
 				'SafeButNotConsensual')
-		palantirJavaFormat('2.47.0').style("PALANTIR").formatJavadoc(true)
+		palantirJavaFormat('2.94.0').style("PALANTIR").formatJavadoc(true)
 		formatAnnotations()
 		trimTrailingWhitespace()
 		endWithNewline()


### PR DESCRIPTION
Reduce Dependabot noise by switching GitHub Actions and Gradle updates to monthly checks and capping open update PRs at 5. Also normalize YAML quoting in the grouped update types.